### PR TITLE
Switch default model to o3-mini

### DIFF
--- a/script.js
+++ b/script.js
@@ -112,7 +112,7 @@ Assistant:
 
     // Request (streaming)
     const aiStream = await aiService.chat(finalPrompt, {
-      model: "claude-3-5-sonnet",
+      model: "o3-mini",
       stream: true
     });
 


### PR DESCRIPTION
## Summary
- default to the `o3-mini` model for chat completion

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6851630d6fdc832b8c82d5297dae9c83